### PR TITLE
Issue-1: Italics and In-Line Code Formatting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,26 @@
+# Build Results
+.vs/
+x64/
+x686/
+[Bb]in/
+[Dd]ebug/
+[Ll]og
+[Oo]bj/
+[Rr]elease/
 
-#ignore thumbnails created by windows
-Thumbs.db
-#Ignore files build by Visual Studio
-*.csproj.user
-bin/
-obj/
-CLI.Package.MSI/
-CLI.Package.ZIP/
+
+# MSTest Test Results
+[Tt]est[Rr]esults*/
+[Bb]uild[Ll]og.*/
+
+
+# Various File Suffixes
+*.exe
+*.meta
+*.obj
+*.pdb
+*.pgc
+*.pgd
+*.svclog
+*.temp*
+*.tmp*

--- a/Engine.Tests.Data/Comments/Natural Docs/Summaries/Formatting - Expected Output.txt
+++ b/Engine.Tests.Data/Comments/Natural Docs/Summaries/Formatting - Expected Output.txt
@@ -1,1 +1,1 @@
-Formatting such as <b>bold</b> and <u>underline</u> and <link type="naturaldocs" originaltext="&lt;links&gt;"> should not affect the summary.  Here's a <b>second</b> <u>sentence</u> with <link type="naturaldocs" originaltext="&lt;them&gt;"> too.
+Formatting such as <b>bold</b>, <u>underline</u>, <i>italics</i>, <code>code</code>, and <link type="naturaldocs" originaltext="&lt;links&gt;"> should not affect the summary.  Here's a <b>second</b> <u>sentence</u> <code>with<code> <link type="naturaldocs" originaltext="&lt;them&gt;"> <i>too</i>.

--- a/Engine.Tests.Data/Comments/Natural Docs/Summaries/Formatting - Input.txt
+++ b/Engine.Tests.Data/Comments/Natural Docs/Summaries/Formatting - Input.txt
@@ -1,7 +1,7 @@
 
 Topic: Test
 
-	Formatting such as *bold* and _underline_ and <links> should not affect the summary.  Here's
-	a *second* _sentence_ with <them> too.
+	Formatting such as *bold*, _underline_, /italics/, `code`, and <links> should not affect the summary.  Here's
+	a *second* _sentence_ `with` <them> /too/.
 
 	This is a second paragraph which shouldn't be included.

--- a/Engine/Source/NDMarkup/Iterator.cs
+++ b/Engine/Source/NDMarkup/Iterator.cs
@@ -46,7 +46,7 @@ namespace CodeClear.NaturalDocs.Engine.NDMarkup
 				BulletListTag, BulletListItemTag,
 				DefinitionListTag, DefinitionListEntryTag, DefinitionListSymbolTag, DefinitionListDefinitionTag,
 
-				BoldTag, ItalicsTag, UnderlineTag,
+				BoldTag, ItalicsTag, UnderlineTag, CodeTag,
 				LinkTag,
 
 			HighestTagValue
@@ -79,6 +79,7 @@ namespace CodeClear.NaturalDocs.Engine.NDMarkup
 			TagNameToElementType.Add("b", ElementType.BoldTag);
 			TagNameToElementType.Add("i", ElementType.ItalicsTag);
 			TagNameToElementType.Add("u", ElementType.UnderlineTag);
+			TagNameToElementType.Add("code", ElementType.CodeTag);
 			TagNameToElementType.Add("link", ElementType.LinkTag);
 
 			EntityCharToElementType = new Collections.StringTable<ElementType>();

--- a/Engine/Source/Output/Components/HTMLTopic.cs
+++ b/Engine/Source/Output/Components/HTMLTopic.cs
@@ -312,6 +312,7 @@ namespace CodeClear.NaturalDocs.Engine.Output.Components
 					case NDMarkup.Iterator.ElementType.BoldTag:
 					case NDMarkup.Iterator.ElementType.ItalicsTag:
 					case NDMarkup.Iterator.ElementType.UnderlineTag:
+					case NDMarkup.Iterator.ElementType.CodeTag:
 					case NDMarkup.Iterator.ElementType.LTEntityChar:
 					case NDMarkup.Iterator.ElementType.GTEntityChar:
 					case NDMarkup.Iterator.ElementType.AmpEntityChar:

--- a/NaturalDocs.sln
+++ b/NaturalDocs.sln
@@ -1,0 +1,37 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.29709.97
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine", "Engine\Engine.csproj", "{F7569B05-FFFD-4084-8F33-760F3E1916CD}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine.Tests", "Engine.Tests\Engine.Tests.csproj", "{1D2F367F-A491-417F-A66A-76E49DA9BD78}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Engine.Tests.Runner", "Engine.Tests.Runner\Engine.Tests.Runner.csproj", "{5901FC36-606E-4D87-B244-BCD76BD34210}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x86 = Debug|x86
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Debug|x86.ActiveCfg = Debug|x86
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Debug|x86.Build.0 = Debug|x86
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Release|x86.ActiveCfg = Release|x86
+		{F7569B05-FFFD-4084-8F33-760F3E1916CD}.Release|x86.Build.0 = Release|x86
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Debug|x86.ActiveCfg = Debug|x86
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Debug|x86.Build.0 = Debug|x86
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Release|x86.ActiveCfg = Release|x86
+		{1D2F367F-A491-417F-A66A-76E49DA9BD78}.Release|x86.Build.0 = Release|x86
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Debug|x86.ActiveCfg = Debug|x86
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Debug|x86.Build.0 = Debug|x86
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Release|x86.ActiveCfg = Release|x86
+		{5901FC36-606E-4D87-B244-BCD76BD34210}.Release|x86.Build.0 = Release|x86
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {90D6BE6E-0682-4EE0-8FB8-832ED7A1A339}
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Italics and in-line code formatting are now fully supported, with the syntax being /italics/ and `code`. This somewhat mirrors the existing *bold* and _underline_ syntaxes. Italics mix with bold and underline, but in-line code formatting must be standalone. (Resolves open issue #1.)

Also adds a .sln file for ease of local development.